### PR TITLE
Fixed bug in platinum that was causing segfault

### DIFF
--- a/wrap1.pyx
+++ b/wrap1.pyx
@@ -122,7 +122,7 @@ def platinum(np.ndarray[double, ndim=1, mode="c"] x not None, int fs, double per
     cdef int fft_size = GetFFTSizeForCheapTrick(fs)
 
     cdef double[:,::1] spectrogram = np_spectrogram
-    cdef double[:,::1] residual = np.zeros((f0_length,fft_size/2+1))
+    cdef double[:,::1] residual = np.zeros((f0_length,fft_size+1))
 
     cdef np.intp_t[:] tmp = np.zeros(f0_length, dtype=np.intp)
     cdef np.intp_t[:] tmp2 = np.zeros(f0_length, dtype=np.intp)


### PR DESCRIPTION
I finally found the bug that was causing segfaults. In `platinum`, the residual variable has `f0_length` rows and `fft_size+1` columns, but you allocated only `fft_size/2+1` columns (this is the right amount of columns for the spectrogram, but not for the residual).

~~This works for me on OS X but I am going to test on Linux as well.~~

EDIT: Tested on Linux in the lab machines and it fixes the segfaults there as well.
